### PR TITLE
quitando lazys a las menos imporantes

### DIFF
--- a/Code/Client/src/app/app-routing.module.ts
+++ b/Code/Client/src/app/app-routing.module.ts
@@ -1,35 +1,22 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 import { IniciarSesionComponent } from './componentes/usuario/iniciar-sesion/iniciar-sesion.component';
+import { PantallaMainComponent } from './componentes/cliente_modulo/pantalla-main/pantalla-main.component';
+import { ObjetoComponent } from './componentes/cliente_modulo/clic_objeto/objeto.component';
+import { CarritoComponent } from './componentes/cliente_modulo/carrito/carrito.component';
 
 const routes: Routes = [
   { path: '', redirectTo: '/Iniciar-Sesion', pathMatch: 'full' },
   { path: 'Iniciar-Sesion', component: IniciarSesionComponent },
+  { path: 'home', component: PantallaMainComponent },
+  { path: 'Objeto/:id', component: ObjetoComponent },
+  { path: 'Carrito', component: CarritoComponent },
+  { path: 'ConfirmarReserva', component: CarritoComponent },
   // Lazy loading - solo carga cuando el usuario navega a estas rutas
   { 
     path: 'admin', 
     loadComponent: () => import('./componentes/admin_modulo/administrador/administrador.component')
       .then(m => m.AdministradorComponent) 
-  },
-  { 
-    path: 'home', 
-    loadComponent: () => import('./componentes/cliente_modulo/pantalla-main/pantalla-main.component')
-      .then(m => m.PantallaMainComponent) 
-  },
-  { 
-    path: 'Objeto/:id', 
-    loadComponent: () => import('./componentes/cliente_modulo/clic_objeto/objeto.component')
-      .then(m => m.ObjetoComponent) 
-  },
-  { 
-    path: 'Carrito', 
-    loadComponent: () => import('./componentes/cliente_modulo/carrito/carrito.component')
-      .then(m => m.CarritoComponent) 
-  },
-  { 
-    path: 'ConfirmarReserva', 
-    loadComponent: () => import('./componentes/cliente_modulo/carrito/carrito.component')
-      .then(m => m.CarritoComponent) 
   },
   { 
     path: 'Formulario', 


### PR DESCRIPTION
This pull request updates the routing configuration in `app-routing.module.ts` to change how several client module routes are loaded. The main change is switching from lazy loading to eager loading for the `home`, `Objeto/:id`, `Carrito`, and `ConfirmarReserva` routes, which now directly reference their respective components. This may impact initial load performance but can simplify navigation and debugging.

**Routing configuration changes:**

* Changed `home`, `Objeto/:id`, `Carrito`, and `ConfirmarReserva` routes from lazy loading (`loadComponent`) to eager loading by directly referencing their components (`PantallaMainComponent`, `ObjetoComponent`, `CarritoComponent`).
* Added direct imports for the affected components at the top of `app-routing.module.ts`.